### PR TITLE
added font size option

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -26,6 +26,8 @@ suspend-key = u
 
 # The font to use for all text
 font = "Sans"
+# The font size to use for all text 
+font-size = 24
 # The default text color
 text-color = "#080800"
 # The color of the error text

--- a/src/config.c
+++ b/src/config.c
@@ -54,6 +54,8 @@ Config *initialize_config(void)
     // Parse Theme Settings
     config->font = g_key_file_get_string(
         keyfile, "greeter-theme", "font", NULL);
+    config->font_size = g_key_file_get_string(
+        keyfile, "greeter-theme", "font-size", NULL);
     config->text_color =
         parse_greeter_color_key(keyfile, "text-color");
     config->error_color =
@@ -91,6 +93,7 @@ void destroy_config(Config *config)
 {
     free(config->login_user);
     free(config->font);
+    free(config->font_size);
     free(config->text_color);
     free(config->error_color);
     free(config->background_color);

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,7 @@ typedef struct Config_ {
 
     /* Theme Configuration */
     gchar    *font;
+    gchar    *font_size;
     GdkRGBA  *text_color;
     GdkRGBA  *error_color;
     // Windows

--- a/src/ui.c
+++ b/src/ui.c
@@ -221,8 +221,8 @@ static void attach_config_colors_to_screen(Config *config)
             "box-shadow: none;\n"
             "border-image-width: 0;\n"
         "}\n"
-        , config->font
         , config->font_size
+        , config->font
         , gdk_rgba_to_string(config->text_color)
         , gdk_rgba_to_string(config->error_color)
         , gdk_rgba_to_string(config->background_color)

--- a/src/ui.c
+++ b/src/ui.c
@@ -194,7 +194,7 @@ static void attach_config_colors_to_screen(Config *config)
     char *css;
     int css_string_length = asprintf(&css,
         "* {\n"
-            "font-family: %s;\n"
+            "font: %s %s;\n"
         "}\n"
         "GtkLabel {\n"
             "color: %s;\n"
@@ -222,6 +222,7 @@ static void attach_config_colors_to_screen(Config *config)
             "border-image-width: 0;\n"
         "}\n"
         , config->font
+        , config->font_size
         , gdk_rgba_to_string(config->text_color)
         , gdk_rgba_to_string(config->error_color)
         , gdk_rgba_to_string(config->background_color)


### PR DESCRIPTION
Using 'font-family:' and 'font-size:' didn't seem to work for me, not sure why that was. 

So append the size to 'font:' tag, it works but not the cleanest method i guess.  