### PR TITLE
Make Autotools to use LDADD instead of LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,6 @@ lightdm_mini_greeter_CFLAGS = \
 							$(AM_CFLAGS) \
 							$(GTK_CFLAGS) \
 							$(LIGHTDM_CFLAGS)
-lightdm_mini_greeter_LDFLAGS = \
+lightdm_mini_greeter_LDADD = \
 							$(GTK_LIBS) \
 							$(LIGHTDM_LIBS)


### PR DESCRIPTION
This fixes building at least for Xubuntu 17.10.1 and GCC 7.2.0.
Without this change, the build fails with undefined LightDM and GTK references.
Some Googling suggests that LDADD is the preferred way to add libraries with Automake. See e.g. https://stackoverflow.com/a/4241813/1592544