### PR TITLE
Make alignment of password input a configurable value

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -11,6 +11,8 @@ show-password-label = true
 password-label-text = Password:
 # Show a blinking cursor in the password input.
 show-input-cursor = true
+# Alignment of the text in password input (0 for left; 1 for right)
+password-alignment = 1
 
 
 [greeter-hotkeys]

--- a/src/config.c
+++ b/src/config.c
@@ -43,6 +43,8 @@ Config *initialize_config(void)
     }
     config->show_input_cursor = g_key_file_get_boolean(
         keyfile, "greeter", "show-input-cursor", NULL);
+    config->password_alignment = g_key_file_get_boolean(
+        keyfile, "greeter", "password-alignment", NULL);
 
     // Parse Hotkey Settings
     config->suspend_key = parse_greeter_hotkey_keyval(keyfile, "suspend-key");

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,7 @@ typedef struct Config_ {
     gboolean  show_password_label;
     gchar    *password_label_text;
     gboolean  show_input_cursor;
+    gboolean  password_alignment;
 
     /* Theme Configuration */
     gchar    *font;

--- a/src/ui.c
+++ b/src/ui.c
@@ -177,7 +177,7 @@ static void create_and_attach_password_field(Config *config, UI *ui)
 {
     ui->password_input = gtk_entry_new();
     gtk_entry_set_visibility(GTK_ENTRY(ui->password_input), FALSE);
-    gtk_entry_set_alignment(GTK_ENTRY(ui->password_input), 1);
+    gtk_entry_set_alignment(GTK_ENTRY(ui->password_input), (gfloat) config->password_alignment);
     gtk_widget_set_name(GTK_WIDGET(ui->password_input), "password");
     gtk_grid_attach(ui->layout_container, ui->password_input, 0, 0, 1, 1);
 


### PR DESCRIPTION
Add a configurable value to change password alignment

Default value in modified default config is set to right-align to preserve behaviour from old code.