### PR TITLE
Make invalid password text configurable

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -9,6 +9,9 @@ user = CHANGE_ME
 show-password-label = true
 # The text of the password input's label.
 password-label-text = Password:
+# Text to show when the user has entered an invalid password
+# Empty value is also valid to show no failure indication
+invalid-password-text = Invalid Password
 # Show a blinking cursor in the password input.
 show-input-cursor = true
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -29,11 +29,13 @@ void authentication_complete_cb(LightDMGreeter *greeter, App *app)
             g_message("Unable to start session");
         }
     } else {
-        if (!gtk_widget_get_visible(APP_FEEDBACK_LABEL(app))) {
-            gtk_widget_show(APP_FEEDBACK_LABEL(app));
+        if (strlen(app->config->invalid_password_text) > 0) {
+           if (!gtk_widget_get_visible(APP_FEEDBACK_LABEL(app))) {
+                gtk_widget_show(APP_FEEDBACK_LABEL(app));
+            }
+            gtk_label_set_text(GTK_LABEL(APP_FEEDBACK_LABEL(app)),
+                               app->config->invalid_password_text);
         }
-        gtk_label_set_text(GTK_LABEL(APP_FEEDBACK_LABEL(app)),
-                           "Invalid Password");
         begin_authentication_as_default_user(app);
     }
 }

--- a/src/config.c
+++ b/src/config.c
@@ -41,6 +41,11 @@ Config *initialize_config(void)
     if (config->password_label_text == NULL) {
         config->password_label_text = (gchar *) "Password:";
     }
+    config->invalid_password_text = g_key_file_get_string(
+        keyfile, "greeter", "invalid-password-text", NULL);
+    if (config->invalid_password_text == NULL) {
+        config->invalid_password_text = (gchar *) "Invalid Password";
+    }
     config->show_input_cursor = g_key_file_get_boolean(
         keyfile, "greeter", "show-input-cursor", NULL);
 
@@ -117,6 +122,7 @@ void destroy_config(Config *config)
     free(config->border_color);
     free(config->border_width);
     free(config->password_label_text);
+    free(config->invalid_password_text);
     free(config->password_color);
     free(config->password_background_color);
     free(config);

--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,7 @@ typedef struct Config_ {
     gchar    *login_user;
     gboolean  show_password_label;
     gchar    *password_label_text;
+    gchar    *invalid_password_text;
     gboolean  show_input_cursor;
 
     /* Theme Configuration */


### PR DESCRIPTION
Fixes #25

Empty value will not show the feedback label.