### PR TITLE
Added config to configure password input border color and width

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -61,3 +61,7 @@ layout-space = 15
 password-color = "#F8F8F0"
 # The background color of the password input.
 password-background-color = "#1B1D1E"
+# The color of the password input's border.
+password-border-color = "#080800"
+# The width of the password input's border.
+password-border-width = 2px

--- a/src/config.c
+++ b/src/config.c
@@ -89,16 +89,25 @@ Config *initialize_config(void)
         parse_greeter_color_key(keyfile, "window-color");
     config->border_color =
         parse_greeter_color_key(keyfile, "border-color");
+    config->border_width = g_key_file_get_string(
+        keyfile, "greeter-theme", "border-width", NULL);
     config->password_color =
         parse_greeter_color_key(keyfile, "password-color");
     config->password_background_color =
         parse_greeter_color_key(keyfile, "password-background-color");
-    config->password_border_color =
-        parse_greeter_color_key(keyfile, "password-border-color");
+    gchar *temp_password_background_color = g_key_file_get_string(
+        keyfile, "greeter-theme", "password-border-color", NULL);
+    if (temp_password_background_color == NULL) {
+        config->password_border_color = config->border_color;
+    } else {
+        config->password_border_color =
+            parse_greeter_color_key(keyfile, "password-border-color");
+    }
     config->password_border_width = g_key_file_get_string(
         keyfile, "greeter-theme", "password-border-width", NULL);
-    config->border_width = g_key_file_get_string(
-        keyfile, "greeter-theme", "border-width", NULL);
+    if (config->password_border_width == NULL) {
+        config->password_border_width = config->border_width;
+    }
 
     gint layout_spacing = g_key_file_get_integer(
         keyfile, "greeter-theme", "layout-space", NULL);

--- a/src/config.c
+++ b/src/config.c
@@ -93,6 +93,10 @@ Config *initialize_config(void)
         parse_greeter_color_key(keyfile, "password-color");
     config->password_background_color =
         parse_greeter_color_key(keyfile, "password-background-color");
+    config->password_border_color =
+        parse_greeter_color_key(keyfile, "password-border-color");
+    config->password_border_width = g_key_file_get_string(
+        keyfile, "greeter-theme", "password-border-width", NULL);
     config->border_width = g_key_file_get_string(
         keyfile, "greeter-theme", "border-width", NULL);
 
@@ -128,6 +132,7 @@ void destroy_config(Config *config)
     free(config->invalid_password_text);
     free(config->password_color);
     free(config->password_background_color);
+    free(config->password_border_width);
     free(config);
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,8 @@ typedef struct Config_ {
     // Password Input
     GdkRGBA  *password_color;
     GdkRGBA  *password_background_color;
+    GdkRGBA  *password_border_color;
+    gchar    *password_border_width;
 
     /* Hotkeys */
     guint     mod_bit;

--- a/src/ui.c
+++ b/src/ui.c
@@ -262,6 +262,9 @@ static void attach_config_colors_to_screen(Config *config)
             "color: %s;\n"
             "caret-color: %s;\n"
             "background-color: %s;\n"
+            "border-width: %s;\n"
+            "border-color: %s;\n"
+            "border-style: solid;\n"
             "background-image: none;\n"
             "box-shadow: none;\n"
             "border-image-width: 0;\n"
@@ -287,6 +290,8 @@ static void attach_config_colors_to_screen(Config *config)
         , gdk_rgba_to_string(config->password_color)
         , gdk_rgba_to_string(caret_color)
         , gdk_rgba_to_string(config->password_background_color)
+        , config->password_border_width
+        , gdk_rgba_to_string(config->password_border_color)
     );
 
     if (css_string_length >= 0) {


### PR DESCRIPTION
Added `password-border-color` and `password-border-width` (similar to `border-color` and `border-width`). If these options are not specified, they default to `border-color` and `border-width` respectively (as they were originally). The default config has also been updated to have these new options.