### PR TITLE
Add user config file to overwrite values in default

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -8,13 +8,10 @@
 #include "config.h"
 #include "utils.h"
 
-
-static GdkRGBA *parse_greeter_color_key(GKeyFile *keyfile, const char *key_name);
-static guint parse_greeter_hotkey_keyval(GKeyFile *keyfile, const char *key_name);
-static gboolean parse_greeter_password_alignment(GKeyFile *keyfile);
 static gboolean is_rtl_keymap_layout(void);
+static void load_config_from_file(Config *config, const char *path);
+static void set_default_values(Config *config);
 
-/* Initialize the configuration, sourcing the greeter's configuration file */
 Config *initialize_config(void)
 {
     Config *config = malloc(sizeof(Config));
@@ -22,94 +19,193 @@ Config *initialize_config(void)
         g_error("Could not allocate memory for Config");
     }
 
-    // Load the key-value file
-    GKeyFile *keyfile = g_key_file_new();
-    gboolean keyfile_loaded = g_key_file_load_from_file(
-        keyfile, CONFIG_FILE, G_KEY_FILE_NONE, NULL);
-    if (!keyfile_loaded) {
-        g_error("Could not load configuration file.");
+    // First load default config from /etc
+    load_config_from_file(config, CONFIG_FILE);
+
+    // Try to find a local config file
+    char path[1024];
+    sprintf(path, "/home/%s/.config/lightdm-mini-greeter.conf",
+            config->login_user);
+    if (access(path, R_OK) != -1) {
+        load_config_from_file(config, path);
     }
 
-    // Parse values from the keyfile into a Config.
-    config->login_user = g_key_file_get_string(
-        keyfile, "greeter", "user", NULL);
-    if (strcmp(config->login_user, "CHANGE_ME") == 0) {
-        g_message("User configuration value is unchanged.");
-    }
-    config->show_password_label = g_key_file_get_boolean(
-        keyfile, "greeter", "show-password-label", NULL);
-    config->password_label_text = g_key_file_get_string(
-        keyfile, "greeter", "password-label-text", NULL);
-    if (config->password_label_text == NULL) {
-        config->password_label_text = (gchar *) "Password:";
-    }
-    config->invalid_password_text = g_key_file_get_string(
-        keyfile, "greeter", "invalid-password-text", NULL);
-    if (config->invalid_password_text == NULL) {
-        config->invalid_password_text = (gchar *) "Invalid Password";
-    }
-    config->show_input_cursor = g_key_file_get_boolean(
-        keyfile, "greeter", "show-input-cursor", NULL);
-    config->password_alignment = parse_greeter_password_alignment(keyfile);
-
-    // Parse Hotkey Settings
-    config->suspend_key = parse_greeter_hotkey_keyval(keyfile, "suspend-key");
-    config->hibernate_key = parse_greeter_hotkey_keyval(keyfile, "hibernate-key");
-    config->restart_key = parse_greeter_hotkey_keyval(keyfile, "restart-key");
-    config->shutdown_key = parse_greeter_hotkey_keyval(keyfile, "shutdown-key");
-    gchar *mod_key = g_key_file_get_string(
-        keyfile, "greeter-hotkeys", "mod-key", NULL);
-    if (strcmp(mod_key, "control") == 0) {
-        config->mod_bit = GDK_CONTROL_MASK;
-    } else if (strcmp(mod_key, "alt") == 0) {
-        config->mod_bit = GDK_MOD1_MASK;
-    } else if (strcmp(mod_key, "meta") == 0) {
-        config->mod_bit = GDK_SUPER_MASK;
-    } else {
-        g_error("Invalid mod-key configuration value: '%s'\n", mod_key);
-    }
-
-    // Parse Theme Settings
-    config->font = g_key_file_get_string(
-        keyfile, "greeter-theme", "font", NULL);
-    config->font_size = g_key_file_get_string(
-        keyfile, "greeter-theme", "font-size", NULL);
-    config->text_color =
-        parse_greeter_color_key(keyfile, "text-color");
-    config->error_color =
-        parse_greeter_color_key(keyfile, "error-color");
-    config->background_image = g_key_file_get_string(
-        keyfile, "greeter-theme", "background-image", NULL);
-    if (config->background_image == NULL || strcmp(config->background_image, "") == 0) {
-        config->background_image = (gchar *) "\"\"";
-    }
-    config->background_color =
-        parse_greeter_color_key(keyfile, "background-color");
-    config->window_color =
-        parse_greeter_color_key(keyfile, "window-color");
-    config->border_color =
-        parse_greeter_color_key(keyfile, "border-color");
-    config->password_color =
-        parse_greeter_color_key(keyfile, "password-color");
-    config->password_background_color =
-        parse_greeter_color_key(keyfile, "password-background-color");
-    config->border_width = g_key_file_get_string(
-        keyfile, "greeter-theme", "border-width", NULL);
-
-    gint layout_spacing = g_key_file_get_integer(
-        keyfile, "greeter-theme", "layout-space", NULL);
-    if (layout_spacing < 0) {
-        config->layout_spacing = (guint) (-1 * layout_spacing);
-    } else {
-        config->layout_spacing = (guint) layout_spacing;
-    }
-
-
-    g_key_file_free(keyfile);
+    set_default_values(config);
 
     return config;
 }
 
+void set_default_values(Config *config)
+{
+    if (strcmp(config->login_user, "CHANGE_ME") == 0) {
+        g_message("User configuration value is unchanged.");
+    }
+    if (config->password_label_text == NULL) {
+        config->password_label_text = (gchar *) "Password:";
+    }
+    if (config->invalid_password_text == NULL) {
+        config->invalid_password_text = (gchar *) "Invalid Password";
+    }
+    if (config->background_image == NULL ||
+        strcmp(config->background_image, "") == 0) {
+        config->background_image = (gchar *) "\"\"";
+    }
+}
+
+void read_string(gchar **val, GKeyFile *file,
+                 const gchar *group, const gchar *key)
+{
+    gchar *read = g_key_file_get_string(file, group, key, NULL);
+    if (read != NULL) {
+        *val = read;
+    }
+}
+
+void read_bool(gboolean *val, GKeyFile *file,
+               const gchar *group, const gchar *key)
+{
+    GError *err = NULL;
+    gboolean read = g_key_file_get_boolean(file, group, key, &err);
+    if (err == NULL) {
+        *val = read;
+    } else {
+        g_error_free(err);
+    }
+
+}
+
+void read_color(GdkRGBA **val, GKeyFile *file, const char *key_name)
+{
+    gchar *color_string = g_key_file_get_string(
+        file, "greeter-theme", key_name, NULL);
+
+    if (color_string == NULL) return;
+
+    if (strstr(color_string, "#") != NULL) {
+        // Remove quotations from hex color strings
+        remove_char(color_string, '"');
+        remove_char(color_string, '\'');
+    }
+
+    GdkRGBA color;
+
+    gboolean color_was_parsed = gdk_rgba_parse(&color, color_string);
+    if (!color_was_parsed) {
+        g_critical("Could not parse the '%s' setting: %s",
+                   key_name, color_string);
+    }
+
+    *val = gdk_rgba_copy(&color);
+}
+
+void read_alignment(gboolean *val, GKeyFile *keyfile) {
+    gchar *password_alignment_text = g_key_file_get_string(
+        keyfile, "greeter", "password-alignment", NULL);
+
+    if (password_alignment_text == NULL) return;
+
+    // alignment is false for left and true for right
+    gboolean alignment = !(strcmp(password_alignment_text, "left") == 0);
+
+    free(password_alignment_text);
+
+    // The left/right values are switched for RTL layouts.
+    if (is_rtl_keymap_layout()) alignment = ! alignment;
+
+    *val = alignment;
+}
+
+/* Parse a greeter-hotkeys key into the GDKkeyval of it's first character */
+void read_hotkey(guint *val, GKeyFile *keyfile, const char *key_name)
+{
+    gchar *key = g_key_file_get_string(
+        keyfile, "greeter-hotkeys", key_name, NULL);
+
+    if (key == NULL) return;
+
+    if (strcmp(key, "") == 0) {
+        g_error("Configuration contains empty key for '%s'\n", key_name);
+    }
+
+    *val = gdk_unicode_to_keyval((guint) key[0]);
+}
+
+void read_int(guint *val, GKeyFile *file, const char *key_name) {
+    GError *err = NULL;
+    gint read = g_key_file_get_integer(
+        file, "greeter-theme", key_name, &err);
+    if (err != NULL) return;
+    if (read < 0) {
+        *val = (guint) (-1 * read);
+    } else {
+        *val = (guint) read;
+    }
+}
+
+
+
+void load_config_from_file(Config *config, const char *path)
+{
+
+    // Load the key-value file
+    GKeyFile *keyfile = g_key_file_new();
+    gboolean keyfile_loaded = g_key_file_load_from_file(
+        keyfile, path, G_KEY_FILE_NONE, NULL);
+    if (!keyfile_loaded) {
+        g_error("Could not load configuration file.");
+    }
+
+    read_string(&config->login_user, keyfile, "greeter", "user");
+    read_string(&config->password_label_text, keyfile,
+                "greeter", "password-label-text");
+    read_string(&config->invalid_password_text, keyfile,
+                "greeter", "invalid-password-text");
+    read_bool(&config->show_password_label, keyfile,
+              "greeter", "show-password-label");
+    read_bool(&config->show_input_cursor, keyfile,
+              "greeter", "show-input-cursor");
+
+    read_alignment(&config->password_alignment, keyfile);
+
+    // Parse Hotkey Settings
+    read_hotkey(&config->suspend_key, keyfile, "suspend-key");
+    read_hotkey(&config->hibernate_key, keyfile, "hibernate-key");
+    read_hotkey(&config->restart_key, keyfile, "restart-key");
+    read_hotkey(&config->shutdown_key, keyfile, "shutdown-key");
+
+    gchar *mod_key = g_key_file_get_string(
+        keyfile, "greeter-hotkeys", "mod-key", NULL);
+    if (mod_key != NULL) {
+        if (strcmp(mod_key, "control") == 0) {
+            config->mod_bit = GDK_CONTROL_MASK;
+        } else if (strcmp(mod_key, "alt") == 0) {
+            config->mod_bit = GDK_MOD1_MASK;
+        } else if (strcmp(mod_key, "meta") == 0) {
+            config->mod_bit = GDK_SUPER_MASK;
+        }
+    }
+
+    // Parse Theme Settings
+    read_string(&config->font, keyfile, "greeter-theme", "font");
+    read_string(&config->font_size, keyfile, "greeter-theme", "font-size");
+    read_string(&config->background_image, keyfile,
+                "greeter-theme", "background-image");
+    read_string(&config->border_width, keyfile,
+                "greeter-theme", "border-width");
+
+    read_color(&config->text_color, keyfile, "text-color");
+    read_color(&config->error_color, keyfile, "error-color");
+    read_color(&config->background_color, keyfile, "background-color");
+    read_color(&config->window_color, keyfile, "window-color");
+    read_color(&config->border_color, keyfile, "border-color");
+    read_color(&config->password_color, keyfile, "password-color");
+    read_color(&config->password_background_color, keyfile,
+               "password-background-color");
+
+    read_int(&config->layout_spacing, keyfile, "layout-space");
+
+    g_key_file_free(keyfile);
+}
 
 /* Cleanup any memory allocated for the Config */
 void destroy_config(Config *config)
@@ -131,77 +227,6 @@ void destroy_config(Config *config)
     free(config);
 }
 
-
-/* Parse a greeter-colors group key into a newly-allocated GdkRGBA value */
-static GdkRGBA *parse_greeter_color_key(GKeyFile *keyfile, const char *key_name)
-{
-    gchar *color_string = g_key_file_get_string(
-        keyfile, "greeter-theme", key_name, NULL);
-    if (strstr(color_string, "#") != NULL) {
-        // Remove quotations from hex color strings
-        remove_char(color_string, '"');
-        remove_char(color_string, '\'');
-    }
-
-    GdkRGBA *color = malloc(sizeof(GdkRGBA));
-
-    gboolean color_was_parsed = gdk_rgba_parse(color, color_string);
-    if (!color_was_parsed) {
-        g_critical("Could not parse the '%s' setting: %s",
-                   key_name, color_string);
-    }
-
-    return color;
-}
-
-/* Parse a greeter-hotkeys key into the GDKkeyval of it's first character */
-static guint parse_greeter_hotkey_keyval(GKeyFile *keyfile, const char *key_name)
-{
-    gchar *key = g_key_file_get_string(
-        keyfile, "greeter-hotkeys", key_name, NULL);
-
-    if (strcmp(key, "") == 0) {
-        g_error("Configuration contains empty key for '%s'\n", key_name);
-    }
-
-    return gdk_unicode_to_keyval((guint) key[0]);
-}
-
-/* Parse the password input alignment, properly handling RTL layouts.
- *
- * Note that the gboolean returned by this function is meant to be used with
- * the `gtk_entry_set_alignment` function.
- */
-static gboolean parse_greeter_password_alignment(GKeyFile *keyfile) {
-    gboolean initial_alignment;
-
-    gchar *password_alignment_text = g_key_file_get_string(
-        keyfile, "greeter", "password-alignment", NULL);
-    if (password_alignment_text == NULL) {
-        initial_alignment = 1;
-    } else {
-        if (strcmp(password_alignment_text, "left") == 0) {
-            initial_alignment = 0;
-        } else {
-            initial_alignment = 1;
-        }
-        free(password_alignment_text);
-    }
-
-    // The left/right values are switched for RTL layouts.
-    if (is_rtl_keymap_layout()) {
-        if (initial_alignment == 0) {
-            return 1;
-        } else {
-            return 0;
-        }
-    } else {
-        return initial_alignment;
-    }
-}
-
-/* Determine if the default Display's Keymap is in the Right-to-Left direction
- */
 static gboolean is_rtl_keymap_layout(void) {
     GdkDisplay *display = gdk_display_get_default();
     if (display == NULL) {


### PR DESCRIPTION
Addresses #18

The majority of this PR transforms the config code into conditional assignment methods, which will only set a value if it actually read one. This allows us to check either config file for a value, then set fallback values at the end.

This will now try to read any config values from the old location in `/etc/lightdm` as well as `/home/$login_user/.config/`.