### PR TITLE
Don't set background-image in default conf to empty string

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -56,7 +56,7 @@ error-color = "#F8F8F0"
 # The image will be displayed centered & unscaled.
 # Note: The file should be somewhere that LightDM has permissions to read
 #       (e.g., /etc/lightdm/).
-background-image = ""
+# background-image = ""
 # The screen's background color.
 background-color = "#1B1D1E"
 # The password window's background color


### PR DESCRIPTION
I've been playing with https://github.com/hercules-team/augeas and found that it does not like an empty string as a value for a config item. It includes a Lens for anything in `/etc/lightdm/*.conf` which includes this file. 

Since `config.c` handles a NULL `background-image` value it seems safe to comment this config option out until it is needed. 

This should probably be fixed in augeas too, but I will need time to learn the Lens syntax and this was easy. 