### PR TITLE
Add a check for symlinks and use the obtained path

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -26,10 +26,21 @@ Config *initialize_config(void)
         g_error("Could not allocate memory for Config");
     }
 
+    // Find out if the config file is a symlink
+    GFile *file = g_file_new_for_path(CONFIG_FILE);
+    GFileInfo *fileinfo = g_file_query_info(
+        file, "", G_FILE_QUERY_INFO_NONE, NULL, NULL);
+    const char *filepath = CONFIG_FILE;
+    if (g_file_info_get_is_symlink(fileinfo)) {
+        filepath = g_file_info_get_symlink_target(fileinfo);
+    }
+    g_object_unref(fileinfo);
+    g_object_unref(file);
+
     // Load the key-value file
     GKeyFile *keyfile = g_key_file_new();
     gboolean keyfile_loaded = g_key_file_load_from_file(
-        keyfile, CONFIG_FILE, G_KEY_FILE_NONE, NULL);
+        keyfile, filepath, G_KEY_FILE_NONE, NULL);
     if (!keyfile_loaded) {
         g_error("Could not load configuration file.");
     }


### PR DESCRIPTION
This is a fix for issue #65 

I added a small check and, if it is a symlink, update the config's file path to the target of the symlink.

I am familiar with c programming, but not with the Glib and compiling such projects. Hence this code should be checked by someone who has more knowledge, but I hope this reduces the effort that needs to be put in to solve the issue. 