### PR TITLE
Adding option to set background image size

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -56,9 +56,12 @@ error-color = "#F8F8F0"
 # Note: The file should be somewhere that LightDM has permissions to read
 # (e.g., /etc/lightdm/).
 background-image = ""
-# Background image size: cover, contain
-# (https://www.w3.org/TR/css-backgrounds-3/#background-size)
-background-image-size = cover
+# Background image size:
+# auto: legacy behaviour
+# cover: scale image to fill screen space
+# contain: scale image to fit inside screen space
+# (more options: https://www.w3.org/TR/css-backgrounds-3/#background-size)
+background-image-size = auto
 # The screen's background color.
 background-color = "#1B1D1E"
 # The password window's background color

--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -57,7 +57,7 @@ error-color = "#F8F8F0"
 # (e.g., /etc/lightdm/).
 background-image = ""
 # Background image size:
-# auto: legacy behaviour
+# auto: unscaled
 # cover: scale image to fill screen space
 # contain: scale image to fit inside screen space
 # (more options: https://www.w3.org/TR/css-backgrounds-3/#background-size)

--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -54,7 +54,7 @@ text-color = "#080800"
 error-color = "#F8F8F0"
 # An absolute path to an optional background image.
 # Note: The file should be somewhere that LightDM has permissions to read
-# (e.g., /etc/lightdm/).
+#       (e.g., /etc/lightdm/).
 background-image = ""
 # Background image size:
 # auto: unscaled

--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -53,10 +53,12 @@ text-color = "#080800"
 # The color of the error text
 error-color = "#F8F8F0"
 # An absolute path to an optional background image.
-# The image will be displayed centered & unscaled.
 # Note: The file should be somewhere that LightDM has permissions to read
-#       (e.g., /etc/lightdm/).
+# (e.g., /etc/lightdm/).
 background-image = ""
+# Background image size: cover, contain
+# (https://www.w3.org/TR/css-backgrounds-3/#background-size)
+background-image-size = cover
 # The screen's background color.
 background-color = "#1B1D1E"
 # The password window's background color

--- a/src/config.c
+++ b/src/config.c
@@ -106,6 +106,8 @@ Config *initialize_config(void)
     }
     config->background_color =
         parse_greeter_color_key(keyfile, "background-color");
+    config->background_image_size =
+        parse_greeter_string(keyfile, "greeter-theme", "background-image-size", "cover");
     // Window
     config->window_color =
         parse_greeter_color_key(keyfile, "window-color");
@@ -161,6 +163,7 @@ void destroy_config(Config *config)
     free(config->error_color);
     free(config->background_image);
     free(config->background_color);
+    free(config->background_image_size);
     free(config->window_color);
     free(config->border_color);
     free(config->border_width);

--- a/src/config.c
+++ b/src/config.c
@@ -107,7 +107,7 @@ Config *initialize_config(void)
     config->background_color =
         parse_greeter_color_key(keyfile, "background-color");
     config->background_image_size =
-        parse_greeter_string(keyfile, "greeter-theme", "background-image-size", "cover");
+        parse_greeter_string(keyfile, "greeter-theme", "background-image-size", "auto");
     // Window
     config->window_color =
         parse_greeter_color_key(keyfile, "window-color");

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,7 @@ typedef struct Config_ {
     // Windows
     gchar    *background_image;
     GdkRGBA  *background_color;
+    gchar    *background_image_size;
     GdkRGBA  *window_color;
     GdkRGBA  *border_color;
     gchar    *border_width;

--- a/src/ui.c
+++ b/src/ui.c
@@ -298,6 +298,7 @@ static void attach_config_colors_to_screen(Config *config)
         "#background.with-image {\n"
             "background-image: image(url(%s), %s);\n"
             "background-repeat: no-repeat;\n"
+            "background-size: %s;\n"
             "background-position: center;\n"
         "}\n"
         "#main, #password {\n"
@@ -333,6 +334,8 @@ static void attach_config_colors_to_screen(Config *config)
         // #background.image-background
         , config->background_image
         , gdk_rgba_to_string(config->background_color)
+        // #background image size
+        , config->background_image_size
         // #main, #password
         , config->border_width
         , gdk_rgba_to_string(config->border_color)

--- a/src/ui.c
+++ b/src/ui.c
@@ -334,7 +334,6 @@ static void attach_config_colors_to_screen(Config *config)
         // #background.image-background
         , config->background_image
         , gdk_rgba_to_string(config->background_color)
-        // #background image size
         , config->background_image_size
         // #main, #password
         , config->border_width


### PR DESCRIPTION
Added option to set CSS `background-size` to `background-image`.
New entry in config file called `background-image-size`, which accepts string values.
Basic values for background image sizing is: `cover` and `contain`.
(more options listed here: https://www.w3.org/TR/css-backgrounds-3/#background-size)

With this feature now we can set `show-image-on-all-monitors = true` and `background-image-size = cover` and have nice full screen scaled background images on all monitors, even with different aspect ratio.