### PR TITLE
Add help window with shortcuts

### DIFF
--- a/data/lightdm-mini-greeter.conf
+++ b/data/lightdm-mini-greeter.conf
@@ -39,7 +39,8 @@ hibernate-key = h
 suspend-key = u
 # Cycle through available sessions
 session-key = e
-
+# Help window
+help_key = k
 
 [greeter-theme]
 # A color from X11's `rgb.txt` file, a quoted hex string(`"#rrggbb"`) or a

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -120,6 +120,12 @@ gboolean handle_hotkeys(GtkWidget *widget, GdkEventKey *event, App *app)
         } else if (event->keyval == config->session_key && sessions != NULL) {
             gchar *new_session = focus_ring_next(sessions);
             set_ui_feedback_label(app, new_session);
+        } else if (event->keyval == config->help_key) {
+            if (gtk_widget_is_visible(GTK_WIDGET(app->ui->help_window))) {
+                gtk_widget_hide(GTK_WIDGET(app->ui->help_window));
+            } else {
+                gtk_widget_show(GTK_WIDGET(app->ui->help_window));
+            }
         } else {
             return FALSE;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -72,6 +72,7 @@ Config *initialize_config(void)
     config->restart_key = parse_greeter_hotkey_keyval(keyfile, "restart-key", 'r');
     config->shutdown_key = parse_greeter_hotkey_keyval(keyfile, "shutdown-key", 's');
     config->session_key = parse_greeter_hotkey_keyval(keyfile, "session-key", 'e');
+    config->help_key = parse_greeter_hotkey_keyval(keyfile, "help-key", 'k');
     gchar *mod_key =
         g_key_file_get_string(keyfile, "greeter-hotkeys", "mod-key", NULL);
     if (mod_key == NULL) {

--- a/src/config.h
+++ b/src/config.h
@@ -56,6 +56,7 @@ typedef struct Config_ {
     guint     hibernate_key;
     guint     suspend_key;
     guint     session_key;
+    guint     help_key;
 } Config;
 
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -9,6 +9,7 @@ typedef struct UI_ {
     GtkWindow   **background_windows;
     int         monitor_count;
     GtkWindow   *main_window;
+    GtkWindow   *help_window;
     GtkGrid     *layout_container;
     GtkGrid     *info_container;
     GtkWidget   *sys_info_label;


### PR DESCRIPTION
Add help window with shortcuts. Look like this:
![изображение](https://user-images.githubusercontent.com/8698003/195773991-b5222860-e1c8-4ec8-8ee0-86f9c6a4331c.png)
To show/hide this window `mod+k` shortcut is used.